### PR TITLE
Bad link to simple backend's urls.py

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -236,7 +236,7 @@ structure:
 
    urlpatterns = [
        # Other URL patterns ...
-       url(r'^accounts/', include('registration.simple.hmac.urls')),
+       url(r'^accounts/', include('registration.backends.simple.urls')),
        # More URL patterns ...
    ]
 


### PR DESCRIPTION
`registration.simple.hmac.urls` does not exist.