### PR TITLE
Email is not required in registration form using HMAC backend

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -51,7 +51,6 @@ class RegistrationForm(UserCreationForm):
         if getattr(settings, 'ACCOUNT_ACTIVATION_DAYS'):
             self.fields['email'].required = True
 
-
     def clean(self):
         """
         Apply the reserved-name validator to the username.

--- a/registration/forms.py
+++ b/registration/forms.py
@@ -10,6 +10,7 @@ django-registration.
 """
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
 from django.core.exceptions import ValidationError
@@ -43,6 +44,13 @@ class RegistrationForm(UserCreationForm):
             'password2'
         ]
         required_css_class = 'required'
+
+    def __init__(self, *args, **kwargs):
+        super(RegistrationForm, self).__init__(*args, **kwargs)
+
+        if getattr(settings, 'ACCOUNT_ACTIVATION_DAYS'):
+            self.fields['email'].required = True
+
 
     def clean(self):
         """


### PR DESCRIPTION
Self explanatory. Despite the activation email will still be sent but with empty "To" field.