### PR TITLE
Pass user to email activation template

### DIFF
--- a/docs/model-workflow.rst
+++ b/docs/model-workflow.rst
@@ -159,6 +159,9 @@ the database, using the following model:
           The number of days the user has to activate, taken from the
           setting ``ACCOUNT_ACTIVATION_DAYS``.
 
+      ``user``
+          The user registering for the new account.
+
       ``site``
           An object representing the site on which the account was
           registered; depending on whether ``django.contrib.sites`` is

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -165,6 +165,9 @@ being used. This template has the following context:
     The number of days remaining during which the account may be
     activated.
 
+``user``
+    The user registering for the new account.
+
 ``site``
     An object representing the site on which the user registered;
     depending on whether ``django.contrib.sites`` is installed, this

--- a/registration/backends/hmac/views.py
+++ b/registration/backends/hmac/views.py
@@ -85,6 +85,9 @@ class RegistrationView(BaseRegistrationView):
         """
         activation_key = self.get_activation_key(user)
         context = self.get_email_context(activation_key)
+        context.update({
+            'user': user
+        })
         subject = render_to_string(self.email_subject_template,
                                    context)
         # Force subject to a single line to avoid header-injection

--- a/registration/models.py
+++ b/registration/models.py
@@ -152,6 +152,7 @@ class RegistrationProfile(models.Model):
         """
         ctx_dict = {'activation_key': self.activation_key,
                     'expiration_days': settings.ACCOUNT_ACTIVATION_DAYS,
+                    'user': self.user,
                     'site': site}
         subject = render_to_string('registration/activation_email_subject.txt',
                                    ctx_dict)


### PR DESCRIPTION
It's quite handy being able to reference the user by name in the activation email.