### PR TITLE
documentation change to the quick start guide

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -7,6 +7,17 @@ First you'll need to have Django and ``django-registration``
 installed; for details on that, see :ref:`the installation guide
 <install>`.
 
+Before proceeding with either of the recommended built-in workflows,
+add ``INSTALLED_APPS += ('django.contrib.auth')`` to ``settings.py``,
+then run ``manage.py migrate`` to install needed database tables.
+
+Also, if you're making use of `a
+custom user model
+<https://docs.djangoproject.com/en/stable/topics/auth/customizing/#substituting-a-custom-user-model>`_,
+you'll probably want to pause and read :ref:`the custom user
+compatibility guide <custom-user>` before using
+``django-registration``.
+
 The next steps will depend on which registration workflow you'd like
 to use. There are three workflows built in to ``django-registration``;
 one is included largely for backwards compatibility with older
@@ -23,15 +34,6 @@ installations. Those two are:
 
 The guide below covers use of these two workflows.
 
-Before proceeding with either of the recommended built-in workflows,
-you'll need to ensure ``django.contrib.auth`` has been installed (by
-adding it to ``INSTALLED_APPS`` and running ``manage.py migrate`` to
-install needed database tables). Also, if you're making use of `a
-custom user model
-<https://docs.djangoproject.com/en/stable/topics/auth/customizing/#substituting-a-custom-user-model>`_,
-you'll probably want to pause and read :ref:`the custom user
-compatibility guide <custom-user>` before using
-``django-registration``.
 
 
 Configuring the HMAC activation workflow


### PR DESCRIPTION
I was working with someone who clicked straight to the one-step workflow and missed the part about adding this to INSTALLED_APPS. Moved that up in the documentation and made it clearer what to do.