### PR TITLE
Split "expired" concept into expired (and unused) and activated (used)

### DIFF
--- a/registration/management/commands/deleteusedregistrations.py
+++ b/registration/management/commands/deleteusedregistrations.py
@@ -1,0 +1,19 @@
+"""
+A management command which deletes used regiatration profiles (e.g.
+the registration code for users that have allready activated) from the database.
+
+Calls ``RegistrationProfile.objects.delete_activated_profiles()``, which
+contains the actual logic for determining which accounts are deleted.
+
+"""
+
+from django.core.management.base import BaseCommand
+
+from registration.models import RegistrationProfile
+
+
+class Command(BaseCommand):
+    help = "Delete used registration codes from the database"
+
+    def handle(self, **options):
+        RegistrationProfile.objects.delete_activated_profiles()

--- a/registration/management/commands/deleteusedregistrations.py
+++ b/registration/management/commands/deleteusedregistrations.py
@@ -1,6 +1,7 @@
 """
-A management command which deletes used regiatration profiles (e.g.
-the registration code for users that have allready activated) from the database.
+A management command which deletes used regiatration profiles
+(e.g. the registration code for users that have allready activated)
+from the database.
 
 Calls ``RegistrationProfile.objects.delete_activated_profiles()``, which
 contains the actual logic for determining which accounts are deleted.

--- a/registration/models.py
+++ b/registration/models.py
@@ -149,7 +149,6 @@ class RegistrationManager(models.Manager):
             profile.delete()
 
 
-
 @python_2_unicode_compatible
 class RegistrationProfile(models.Model):
     """

--- a/registration/models.py
+++ b/registration/models.py
@@ -61,9 +61,18 @@ class RegistrationManager(models.Manager):
                 return user
         return False
 
+    def activated(self):
+        """
+        Query for all profiles which are used and no longer needed.
+
+        """
+        return self.filter(
+            activation_key=self.model.ACTIVATED
+        )
+
     def expired(self):
         """
-        Query for all profiles which are expired and correspond to
+        Query for all profiles which are unused, expired and correspond to
         non-active users.
 
         """
@@ -72,15 +81,18 @@ class RegistrationManager(models.Manager):
         else:
             now = datetime.datetime.now()
         return self.exclude(
-            user__is_active=True
-            ).filter(
-                models.Q(activation_key=self.model.ACTIVATED) |
-                models.Q(
-                    user__date_joined__lt=now - datetime.timedelta(
-                        settings.ACCOUNT_ACTIVATION_DAYS
-                    )
-                )
+            # Don't include activated profiles
+            # (we don't want to delete users who has actually logged in)
+            activation_key=self.model.ACTIVATED
+        ).exclude(
+            user__is_active=True  # Don't include active users
+            # (we don't want to delete active users)
+        ).filter(
+            # Find expired codes
+            user__date_joined__lt=now - datetime.timedelta(
+                settings.ACCOUNT_ACTIVATION_DAYS
             )
+        )
 
     @transaction.atomic
     def create_inactive_user(self, form, site, send_email=True):
@@ -118,13 +130,24 @@ class RegistrationManager(models.Manager):
     def delete_expired_users(self):
         """
         Remove expired instances of ``RegistrationProfile`` and their
-        associated users.
+        inactive associated users.
 
         """
         for profile in self.expired():
             user = profile.user
             profile.delete()
             user.delete()
+
+    @transaction.atomic
+    def delete_activated_profiles(self):
+        """
+        Remove used instances of ``RegistrationProfile``.
+        (Does not touch their associated users)
+        """
+
+        for profile in self.activated():
+            profile.delete()
+
 
 
 @python_2_unicode_compatible

--- a/registration/tests/test_models.py
+++ b/registration/tests/test_models.py
@@ -363,7 +363,6 @@ class RegistrationModelTests(TestCase):
         used_profile.activation_key = RegistrationProfile.ACTIVATED
         used_profile.save()
 
-
         self.assertEqual(RegistrationProfile.objects.count(), 2)
 
         management.call_command('deleteusedregistrations')


### PR DESCRIPTION
Fix for issue #48

Added new management command to delete used activation codes without touching the users.

The cleanupregistration command now only deletes unused expired profiles and their users while not touching users that have used their registration code.
