### PR TITLE
Proposed fix for #50

### DIFF
--- a/registration/backends/hmac/views.py
+++ b/registration/backends/hmac/views.py
@@ -12,6 +12,7 @@ from django.core import signing
 from django.template.loader import render_to_string
 
 from registration import signals
+from registration.exceptions import BadActivationKey, ActivationKeyExpired
 from registration.views import ActivationView as BaseActivationView
 from registration.views import RegistrationView as BaseRegistrationView
 
@@ -137,8 +138,10 @@ class ActivationView(BaseActivationView):
             return username
         # SignatureExpired is a subclass of BadSignature, so this will
         # catch either one.
+        except signing.SignatureExpired:
+            raise ActivationKeyExpired
         except signing.BadSignature:
-            return None
+            raise BadActivationKey
 
     def get_user(self, username):
         """

--- a/registration/exceptions.py
+++ b/registration/exceptions.py
@@ -1,0 +1,11 @@
+"""
+Some exceptions class that can be used to catch common errors
+"""
+
+
+class BadActivationKey(Exception):
+    pass
+
+
+class ActivationKeyExpired(Exception):
+    pass

--- a/registration/models.py
+++ b/registration/models.py
@@ -24,6 +24,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
+from registration.exceptions import BadActivationKey, ActivationKeyExpired
 
 SHA1_RE = re.compile('^[a-f0-9]{40}$')
 
@@ -51,7 +52,7 @@ class RegistrationManager(models.Manager):
             try:
                 profile = self.get(activation_key=activation_key)
             except self.model.DoesNotExist:
-                return False
+                raise BadActivationKey
             if not profile.activation_key_expired():
                 user = profile.user
                 user.is_active = True
@@ -59,6 +60,8 @@ class RegistrationManager(models.Manager):
                 profile.activation_key = self.model.ACTIVATED
                 profile.save()
                 return user
+            else:
+                raise ActivationKeyExpired
         return False
 
     def expired(self):

--- a/registration/signals.py
+++ b/registration/signals.py
@@ -11,3 +11,6 @@ user_registered = Signal(providing_args=["user", "request"])
 
 # A user has activated his or her account.
 user_activated = Signal(providing_args=["user", "request"])
+
+# A user activation failed.
+user_activation_failed = Signal(providing_args=["request"])

--- a/registration/views.py
+++ b/registration/views.py
@@ -110,6 +110,12 @@ class ActivationView(TemplateView):
                 return redirect(to, *args, **kwargs)
             except ValueError:
                 return redirect(success_url)
+        else:
+            signals.user_activation_failed.send(
+                sender=self.__class__,
+                request=self.request
+            )
+
         return super(ActivationView, self).get(*args, **kwargs)
 
     def activate(self, *args, **kwargs):


### PR DESCRIPTION
This PR is an attempt to fix some issues described in #50 Of course, you are totally free to accept or decline the PR, or use all or parts of the code to resolve the issue in another way.

I know this PR will break the unit tests. This is due to the changes on the behavior of `activate_user` in HMAC and models based backends. From this PR, the method now raise 2 kinds of exceptions when the activation process failed at some point:
- BadActivationKey
- ActivationKeyExpired

These exceptions are catched in `ActivationView.get()` so a different template is loaded in such cases.
