### PR TITLE
Add support for alternative HTML template for account activation email

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -25,6 +25,58 @@ of several custom settings.
    * :ref:`The model-based activation workflow <model-workflow>`
 
 
+.. data:: ACCOUNT_ACTIVATION_EMAIL_SUBJECT_TEMPLATE
+
+   A ``path`` to a plain-text template used to render activation email subject.
+
+   This setting is optional, and a default of
+   ``registration/activation_email_subject.html`` will be used if not specified.
+
+   A ``TemplateSyntaxError`` will be raised if the specified template could not
+   be found.
+
+   Used by:
+
+   * :ref:`The two-step HMAC activation workflow <hmac-workflow>`
+
+   * :ref:`The model-based activation workflow <model-workflow>`
+
+
+.. data:: ACCOUNT_ACTIVATION_EMAIL_BODY_TEMPLATE
+
+   A ``path`` to a plain-text template used to render activation email body.
+
+   This setting is optional, and a default of
+   ``registration/activation_email.txt`` will be used if not specified.
+
+   A ``TemplateSyntaxError`` will be raised if the specified template could not
+   be found.
+
+   Used by:
+
+   * :ref:`The two-step HMAC activation workflow <hmac-workflow>`
+
+   * :ref:`The model-based activation workflow <model-workflow>`
+
+
+.. data:: ACCOUNT_ACTIVATION_EMAIL_HTML_BODY_TEMPLATE
+
+   A ``path`` to an optional alternative HTML template used to render
+   activation email body.
+
+   This setting is optional, and a default of
+   ``registration/activation_email.html`` will be used if not specified.
+
+   If the specified template could not be found, no HTML alternative email body
+   will be sent.
+
+   Used by:
+
+   * :ref:`The two-step HMAC activation workflow <hmac-workflow>`
+
+   * :ref:`The model-based activation workflow <model-workflow>`
+
+
 .. data:: REGISTRATION_OPEN
 
    A ``bool`` indicating whether registration of new accounts is

--- a/registration/backends/hmac/views.py
+++ b/registration/backends/hmac/views.py
@@ -9,7 +9,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sites.shortcuts import get_current_site
 from django.core import signing
-from django.template.loader import render_to_string
 
 from registration import signals
 from registration.utils import send_user_activation_email
@@ -90,7 +89,7 @@ class RegistrationView(BaseRegistrationView):
         email_ctx.update({
             'user': user
         })
-        
+
         send_user_activation_email(user, email_ctx,
                                    self.email_subject_template,
                                    self.email_body_template,

--- a/registration/models.py
+++ b/registration/models.py
@@ -24,6 +24,8 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
 
+from registration.utils import send_user_activation_email
+
 
 SHA1_RE = re.compile('^[a-f0-9]{40}$')
 
@@ -169,17 +171,9 @@ class RegistrationProfile(models.Model):
         ``RegistrationProfile``.
 
         """
-        ctx_dict = {'activation_key': self.activation_key,
-                    'expiration_days': settings.ACCOUNT_ACTIVATION_DAYS,
-                    'user': self.user,
-                    'site': site}
-        subject = render_to_string('registration/activation_email_subject.txt',
-                                   ctx_dict)
-        # Force subject to a single line to avoid header-injection
-        # issues.
-        subject = ''.join(subject.splitlines())
-
-        message = render_to_string('registration/activation_email.txt',
-                                   ctx_dict)
-
-        self.user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+        email_ctx = {'activation_key': self.activation_key,
+                     'expiration_days': settings.ACCOUNT_ACTIVATION_DAYS,
+                     'user': self.user,
+                     'site': site}
+        
+        send_user_activation_email(self.user, email_ctx)

--- a/registration/models.py
+++ b/registration/models.py
@@ -18,7 +18,6 @@ import re
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db import models, transaction
-from django.template.loader import render_to_string
 from django.utils.crypto import get_random_string
 from django.utils.encoding import python_2_unicode_compatible
 from django.utils import timezone
@@ -175,5 +174,5 @@ class RegistrationProfile(models.Model):
                      'expiration_days': settings.ACCOUNT_ACTIVATION_DAYS,
                      'user': self.user,
                      'site': site}
-        
+
         send_user_activation_email(self.user, email_ctx)

--- a/registration/utils.py
+++ b/registration/utils.py
@@ -8,13 +8,15 @@ def send_user_activation_email(user, email_ctx,
                                email_html_body_template=None):
     """
     Send an activation email to a user.
-    
+
     """
     # Subject of activation email.
     if not email_subject_template:
-        email_subject_template = getattr(settings,
-         'ACCOUNT_ACTIVATION_EMAIL_SUBJECT_TEMPLATE',
-         None)
+        email_subject_template = getattr(
+            settings,
+            'ACCOUNT_ACTIVATION_EMAIL_SUBJECT_TEMPLATE',
+            None
+        )
 
     if not email_subject_template:
         email_subject_template = 'registration/activation_email_subject.txt'
@@ -26,9 +28,11 @@ def send_user_activation_email(user, email_ctx,
 
     # Plain-text body of activation email.
     if not email_body_template:
-        email_body_template = getattr(settings,
-          'ACCOUNT_ACTIVATION_EMAIL_BODY_TEMPLATE',
-          None)
+        email_body_template = getattr(
+            settings,
+            'ACCOUNT_ACTIVATION_EMAIL_BODY_TEMPLATE',
+            None
+        )
 
     if not email_body_template:
         email_body_template = 'registration/activation_email.txt'
@@ -37,9 +41,11 @@ def send_user_activation_email(user, email_ctx,
 
     # HTML alternative of activation email's body.
     if not email_html_body_template:
-        email_html_body_template = getattr(settings,
-          'ACCOUNT_ACTIVATION_EMAIL_HTML_BODY_TEMPLATE',
-          None)
+        email_html_body_template = getattr(
+            settings,
+            'ACCOUNT_ACTIVATION_EMAIL_HTML_BODY_TEMPLATE',
+            None
+        )
 
     if not email_html_body_template:
         email_html_body_template = 'registration/activation_email.html'

--- a/registration/utils.py
+++ b/registration/utils.py
@@ -1,0 +1,54 @@
+from django.conf import settings
+from django.template.loader import render_to_string, TemplateDoesNotExist
+
+
+def send_user_activation_email(user, email_ctx,
+                               email_subject_template=None,
+                               email_body_template=None,
+                               email_html_body_template=None):
+    """
+    Send an activation email to a user.
+    
+    """
+    # Subject of activation email.
+    if not email_subject_template:
+        email_subject_template = getattr(settings,
+         'ACCOUNT_ACTIVATION_EMAIL_SUBJECT_TEMPLATE',
+         None)
+
+    if not email_subject_template:
+        email_subject_template = 'registration/activation_email_subject.txt'
+
+    subject = render_to_string(email_subject_template, email_ctx)
+
+    # Force subject to a single line to avoid header-injection issues.
+    subject = ''.join(subject.splitlines())
+
+    # Plain-text body of activation email.
+    if not email_body_template:
+        email_body_template = getattr(settings,
+          'ACCOUNT_ACTIVATION_EMAIL_BODY_TEMPLATE',
+          None)
+
+    if not email_body_template:
+        email_body_template = 'registration/activation_email.txt'
+
+    message = render_to_string(email_body_template, email_ctx)
+
+    # HTML alternative of activation email's body.
+    if not email_html_body_template:
+        email_html_body_template = getattr(settings,
+          'ACCOUNT_ACTIVATION_EMAIL_HTML_BODY_TEMPLATE',
+          None)
+
+    if not email_html_body_template:
+        email_html_body_template = 'registration/activation_email.html'
+
+    try:
+        html_message = render_to_string(email_html_body_template, email_ctx)
+    except TemplateDoesNotExist:
+        html_message = None
+
+    # Send the rendered activation email.
+    user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL,
+                    html_message=html_message)


### PR DESCRIPTION
It should fix #52.

Templates for activation email could now be specified or by (new provided) settings options or by `ActivationView`'s attributes (for HMAC backend only).

The new settings are:

- `ACCOUNT_ACTIVATION_EMAIL_SUBJECT_TEMPLATE`
- `ACCOUNT_ACTIVATION_EMAIL_BODY_TEMPLATE`
- `ACCOUNT_ACTIVATION_EMAIL_HTML_BODY_TEMPLATE`

The default values guarantee backward compatibility. All tests passed.

**Bonus:** it eliminates code redundancy among HMAC and Model-based backends.