### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,4 +9,4 @@ requires a functional installation of Django 1.8 or newer, but has no
 other dependencies.
 
 Full documentation is `available online
-<https://django-registration.readthedocs.org/>`_.
+<https://django-registration.readthedocs.io/>`_.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -104,7 +104,7 @@ General
 
     Additionally, the ``setup.cfg`` file included in
     ``django-registration`` provides configuration for `coverage.py
-    <https://coverage.readthedocs.org/>`_, enabling
+    <https://coverage.readthedocs.io/>`_, enabling
     easy recording and reporting of test coverage.
 
    

--- a/registration/backends/hmac/__init__.py
+++ b/registration/backends/hmac/__init__.py
@@ -8,6 +8,6 @@ configuration.
 
 For more details, see the documentation in the docs/ directory of the
 source-code distribution, or online at
-http://django-registration.readthedocs.org/
+https://django-registration.readthedocs.io/
 
 """

--- a/registration/backends/model_activation/__init__.py
+++ b/registration/backends/model_activation/__init__.py
@@ -9,6 +9,6 @@ configuration.
 
 For more details, see the documentation in the docs/ directory of the
 source-code distribution, or online at
-http://django-registration.readthedocs.org/
+https://django-registration.readthedocs.io/
 
 """

--- a/registration/backends/simple/__init__.py
+++ b/registration/backends/simple/__init__.py
@@ -8,6 +8,6 @@ configuration.
 
 For more details, see the documentation in the docs/ directory of the
 source-code distribution, or online at
-http://django-registration.readthedocs.org/
+https://django-registration.readthedocs.io/
 
 """


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
