### PR TITLE
Fix a bug with Django user model

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -46,6 +46,7 @@ class RegistrationForm(UserCreationForm):
     )
 
     class Meta(UserCreationForm.Meta):
+        model = User
         fields = [
             User.USERNAME_FIELD,
             'email',


### PR DESCRIPTION
RegistrationForm is inherited from UserCreationForm and uses `model` declaration from it's `Meta`. 

The problem is that user model in UserCreationForm defined in a wrong way, not with get_user_model(), but imported directly from django.contrib.auth.models. It causes a bug during registration if User model is custom.( see issue #69 )

This pull requests fixes the issue.