### PR TITLE
Add PyPI badges to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,9 @@
 .. -*-restructuredtext-*-
 
+.. image:: https://img.shields.io/pypi/v/django-registration.svg
+   :target: https://pypi.python.org/pypi/django-registration
+.. image:: https://img.shields.io/pypi/pyversions/django-registration.svg
+   :target: https://pypi.python.org/pypi/django-registration
 .. image:: https://travis-ci.org/ubernostrum/django-registration.svg?branch=master
     :target: https://travis-ci.org/ubernostrum/django-registration
 


### PR DESCRIPTION
I find these badges very useful to quickly see that the package is released on PyPI and which Python versions are supported. You can also click on the link to quickly verify the PyPI package name.