### PR TITLE
Add support for recaptcha

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -10,16 +10,17 @@ django-registration.
 """
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
 from django.core.exceptions import ValidationError
 from django.utils.translation import ugettext_lazy as _
 
-
 from . import validators
 
-
 User = get_user_model()
+
+REGISTRATION_RECAPTCHA2 = getattr(settings, "REGISTRATION_RECAPTCHA2", False)
 
 
 class RegistrationForm(UserCreationForm):
@@ -44,6 +45,11 @@ class RegistrationForm(UserCreationForm):
         help_text=_(u'email address'),
         required=True
     )
+
+    if REGISTRATION_RECAPTCHA2:
+        from snowpenguin.django.recaptcha2.fields import ReCaptchaField
+        from snowpenguin.django.recaptcha2.widgets import ReCaptchaWidget
+        captcha = ReCaptchaField(widget=ReCaptchaWidget())
 
     class Meta(UserCreationForm.Meta):
         fields = [
@@ -107,6 +113,7 @@ class RegistrationFormUniqueEmail(RegistrationForm):
     email addresses.
 
     """
+
     def clean_email(self):
         """
         Validate that the supplied email address is unique for the

--- a/registration/runtests.py
+++ b/registration/runtests.py
@@ -10,11 +10,9 @@ different settings and/or templates to run their tests.
 import os
 import sys
 
-
 # Make sure the app is (at least temporarily) on the import path.
 APP_DIR = os.path.abspath(os.path.dirname(__file__))
 sys.path.insert(0, APP_DIR)
-
 
 # Minimum settings required for the app's tests.
 SETTINGS_DICT = {
@@ -26,6 +24,7 @@ SETTINGS_DICT = {
         'django.contrib.sites',
         # This is only needed by the model-based activation workflow.
         'registration',
+        'snowpenguin.django.recaptcha2',
     ),
     # Test cases will override this liberally.
     'ROOT_URLCONF': 'registration.backends.default.urls',
@@ -57,6 +56,10 @@ SETTINGS_DICT = {
             ],
         },
     }],
+    'RECAPTCHA_PRIVATE_KEY': 'your private key',
+    'RECAPTCHA_PUBLIC_KEY': 'your public key',
+    'REGISTRATION_RECAPTCHA2': True,
+
 }
 
 

--- a/registration/tests/test_forms.py
+++ b/registration/tests/test_forms.py
@@ -27,6 +27,14 @@ class RegistrationFormTests(RegistrationTestCase):
             form.fields['email'].required
         )
 
+    def test_captcha(self):
+        """
+        Test the captcha field
+
+        """
+        with self.settings(REGISTRATION_RECAPTCHA2=True):
+            forms.RegistrationForm()
+
     def test_username_uniqueness(self):
         """
         Username uniqueness is enforced.

--- a/registration/tests/test_forms.py
+++ b/registration/tests/test_forms.py
@@ -35,6 +35,9 @@ class RegistrationFormTests(RegistrationTestCase):
         with self.settings(REGISTRATION_RECAPTCHA2=True):
             forms.RegistrationForm()
 
+        with self.settings(REGISTRATION_RECAPTCHA2=False):
+            forms.RegistrationForm()
+
     def test_username_uniqueness(self):
         """
         Username uniqueness is enforced.

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,3 @@
 coverage
 flake8
+django-recaptcha2


### PR DESCRIPTION
It will be nice if we could add default support for enabling an captcha in the registration form.

I have done this by using the djnago-recaptcha2 (https://github.com/kbytesys/django-recaptcha2) package. It would load only the captcha if django.conf.settings.REGISTRATION_RECAPTCHA2 evaluates as True.