### PR TITLE
Fixed determining success_url in ActivationView

### DIFF
--- a/registration/views.py
+++ b/registration/views.py
@@ -89,7 +89,7 @@ class ActivationView(TemplateView):
             )
             success_url = self.get_success_url(activated_user) if \
                 (hasattr(self, 'get_success_url') and
-                 callable(self.success_url)) else \
+                 callable(self.get_success_url)) else \
                 self.success_url
             try:
                 to, args, kwargs = success_url


### PR DESCRIPTION
Implementation of get_success_url in overridden ActivationView had no effect IMHO due to bug in the code.