### PR TITLE
Added reverse_lazy() to success_url to avoid redirects to non-existen…

### DIFF
--- a/registration/auth_urls_classes.py
+++ b/registration/auth_urls_classes.py
@@ -6,6 +6,7 @@ URL patterns for the post-1.11 class-based Django auth views.
 import textwrap
 import warnings
 
+from django.urls import reverse_lazy
 from django.conf.urls import url
 from django.contrib.auth import views as auth_views
 
@@ -33,7 +34,7 @@ urlpatterns = [
         name='auth_logout'),
     url(r'^password/change/$',
         auth_views.PasswordChangeView.as_view(
-            success_url='auth_password_change_done'
+            success_url=reverse_lazy('auth_password_change_done')
         ),
         name='auth_password_change'),
     url(r'^password/change/done/$',
@@ -41,7 +42,7 @@ urlpatterns = [
         name='auth_password_change_done'),
     url(r'^password/reset/$',
         auth_views.PasswordResetView.as_view(
-            success_url='auth_password_reset_done'
+            success_url=reverse_lazy('auth_password_reset_done')
         ),
         name='auth_password_reset'),
     url(r'^password/reset/complete/$',
@@ -53,7 +54,7 @@ urlpatterns = [
     url(r'^password/reset/confirm/(?P<uidb64>[0-9A-Za-z_\-]+)/'
         r'(?P<token>[0-9A-Za-z]{1,13}-[0-9A-Za-z]{1,20})/$',
         auth_views.PasswordResetConfirmView.as_view(
-            success_url='auth_password_reset_complete'
+            success_url=reverse_lazy('auth_password_reset_complete')
         ),
         name='auth_password_reset_confirm'),
 ]


### PR DESCRIPTION
I ran into the same issues described in #106, and here's the easy fix for it.

It actually occurs on all 3 redirects (`auth_password_change_done`, `auth_password_reset_done`, `auth_password_reset_complete`). Django's [success_url](https://docs.djangoproject.com/en/1.11/ref/class-based-views/mixins-editing/#django.views.generic.edit.FormMixin.success_url) expects an actual URL, but the strings provided are page names instead. Using the [reverse_lazy](https://docs.djangoproject.com/en/1.11/ref/urlresolvers/#django.urls.reverse_lazy) will provide the expected result.

I don't have my dev area set up to run your formal tests, but I can confirm this solves #106 in my Django project.