### PR TITLE
Redirect authenticated users in registration view

### DIFF
--- a/registration/tests/test_views.py
+++ b/registration/tests/test_views.py
@@ -45,3 +45,16 @@ class ActivationViewTests(RegistrationTestCase):
             )
         )
         self.assertRedirects(resp, '/activate/complete/')
+
+    def test_registration_redirect(self):
+        """
+        ``redirect_authenticated_user``, when ``True``, redirects
+        authenticated users to success_url.
+
+        """
+        self.client.login(**{
+            self.user_model.USERNAME_FIELD: self.valid_data[self.user_model.USERNAME_FIELD],
+            'password': self.valid_data['password1'],
+        })
+        resp = self.client.get(reverse('registration_register_or_redirect'))
+        self.assertRedirects(resp, '/')

--- a/registration/tests/urls.py
+++ b/registration/tests/urls.py
@@ -11,7 +11,7 @@ from django.views.generic.base import TemplateView
 
 from registration.backends.model_activation.views import RegistrationView
 
-from .views import ActivateWithComplexRedirect
+from .views import ActivateWithComplexRedirect, RegistrationWithRedirect
 
 
 urlpatterns = [
@@ -35,6 +35,9 @@ urlpatterns = [
     url(r'^register/$',
         RegistrationView.as_view(),
         name='registration_register'),
+    url(r'^register-or-redirect/$',
+        RegistrationWithRedirect.as_view(),
+        name='registration_register_or_redirect'),
     url(r'^register/complete/$',
         TemplateView.as_view(
             template_name='registration/registration_complete.html'

--- a/registration/tests/views.py
+++ b/registration/tests/views.py
@@ -4,8 +4,14 @@ covered by the built-in workflows.
 
 """
 
+from registration.views import RegistrationView
 from registration.backends.model_activation.views import ActivationView
 
 
 class ActivateWithComplexRedirect(ActivationView):
     success_url = ('registration_activation_complete', (), {})
+
+
+class RegistrationWithRedirect(RegistrationView):
+    redirect_authenticated_user = True
+    success_url = '/'

--- a/registration/views.py
+++ b/registration/views.py
@@ -21,6 +21,7 @@ class RegistrationView(FormView):
     form_class = RegistrationForm
     success_url = None
     template_name = 'registration/registration_form.html'
+    redirect_authenticated_user = False
 
     def dispatch(self, *args, **kwargs):
         """
@@ -28,6 +29,14 @@ class RegistrationView(FormView):
         dispatch or do other processing.
 
         """
+        user = self.request.user
+        is_authenticated = user.is_authenticated() if \
+            (hasattr(user, 'is_authenticated') and
+             callable(user.is_authenticated)) else \
+            user.is_authenticated
+
+        if self.redirect_authenticated_user and is_authenticated:
+            return redirect(settings.LOGIN_REDIRECT_URL) if not self.success_url else redirect(self.success_url)
         if not self.registration_allowed():
             return redirect(self.disallowed_url)
         return super(RegistrationView, self).dispatch(*args, **kwargs)


### PR DESCRIPTION
This could be configurable at URL level, similar to what it is already
possible for the django.contrib.auth 'login' url. See LoginView:
https://github.com/django/django/blob/master/django/contrib/auth/views.py#L39

To make it easy to configure, it redirects to settings.LOGIN_REDIRECT_URL.