### PR TITLE
Fix #124 - Pin Django to 1.11.x in 1.11 tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps =
   -rtest_requirements.txt
   django18: Django>=1.8,<1.9
   django110: Django>=1.10,<1.11
-  django111: Django>=1.11
+  django111: Django>=1.11,<2.0
 
 [travis]
 python =
@@ -38,4 +38,3 @@ python =
   3.4: py34
   3.5: py35
   3.6: py36, docs
- 


### PR DESCRIPTION
Limits the Django version in Tox, ensuring that Tox and Travis do not install Django 2.0 instead of Django 1.11.