### PR TITLE
Document inheriting from RegistrationForm.Meta

### DIFF
--- a/docs/custom-user.rst
+++ b/docs/custom-user.rst
@@ -53,7 +53,7 @@ edit django-registration's code):
 
     
     class MyCustomUserForm(RegistrationForm):
-        class Meta:
+        class Meta(RegistrationForm.Meta):
             model = MyCustomUser
 
 You will also need to specify the fields to include in the form, via


### PR DESCRIPTION
As far as I can tell, the documentation for subclassing the registration form in the case of a custom `User` model doesn't work. But I could be confused! Here's my reasoning.

Per https://docs.djangoproject.com/en/1.11/topics/forms/modelforms/#form-inheritance:

> If you have multiple base classes that declare a Meta inner class, only the first one will be used. This means the child’s Meta, if it exists, otherwise the Meta of the first parent, etc.

Since in this example `MyCustomUserForm.Meta` doesn't inherit from `RegistrationForm.Meta`, the custom form doesn't specify `Meta.fields` which is required for model forms, and Django raises an `ImproperlyConfigured` exception.