### PR TITLE
Adding the right user model to the form's meta

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -49,6 +49,7 @@ class RegistrationForm(UserCreationForm):
     )
 
     class Meta(UserCreationForm.Meta):
+        model = User
         fields = [
             User.USERNAME_FIELD,
             'email',


### PR DESCRIPTION
If you are using a custom User model we need to associate the current get_user_model to the Meta() of the registration form