### PR TITLE
Remove warning regarding Python 3.2 from docs

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -37,7 +37,7 @@ General
 **What versions of Django and Python are supported?**
 
     As of django-registration |release|, Django 1.11 and 2.0 are
-    supported, on Python 2.7, (Django 1.1 only), 3.4, 3.5 and 3.6.
+    supported, on Python 2.7, (Django 1.11 only), 3.4, 3.5 and 3.6.
 
 **I found a bug or want to make an improvement!**
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -17,14 +17,6 @@ The |release| release of django-registration supports Django 1.11 and
 
 * Django 2.0 supports Python 3.4, 3.5 and 3.6.
 
-.. important:: **Python 3.2**
-
-   Although Django 1.8 supported Python 3.2 at the time of its
-   release, the Python 3.2 series has reached end-of-life, and as a
-   result support for Python 3.2 has been dropped from
-   django-registration.
-
-
 Normal installation
 -------------------
 


### PR DESCRIPTION
I noticed that the warning regarding Python 3.2 support is obsolete, as no version of Django supported by django-registration ever supported Python 3.2. I've therefore removed it.