### PR TITLE
allow kwargs in send_activation_email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .tox/
 categories.json
 confusables.json
+.idea

--- a/registration/backends/hmac/views.py
+++ b/registration/backends/hmac/views.py
@@ -79,7 +79,7 @@ class RegistrationView(BaseRegistrationView):
             'site': get_current_site(self.request)
         }
 
-    def send_activation_email(self, user):
+    def send_activation_email(self, user, **kwargs):
         """
         Send the activation email. The activation key is the username,
         signed using TimestampSigner.
@@ -97,7 +97,11 @@ class RegistrationView(BaseRegistrationView):
         subject = ''.join(subject.splitlines())
         message = render_to_string(self.email_body_template,
                                    context)
-        user.email_user(subject, message, settings.DEFAULT_FROM_EMAIL)
+        # if `from_email` is not passed in kwargs get the value
+        # from settings
+        if kwargs.get('from_email') is None:
+            kwargs['from_email'] = getattr(settings, 'DEFAULT_FROM_EMAIL')
+        user.email_user(subject, message, **kwargs)
 
 
 class ActivationView(BaseActivationView):

--- a/registration/tests/templates/registration/activation_email.txt
+++ b/registration/tests/templates/registration/activation_email.txt
@@ -1,0 +1,4 @@
+{{scheme}}
+{{expiration_days}}
+{{site}}
+{{user}}

--- a/registration/tests/templates/registration/activation_email_subject.txt
+++ b/registration/tests/templates/registration/activation_email_subject.txt
@@ -1,0 +1,1 @@
+{{activation_key}}

--- a/registration/tests/test_hmac_workflow.py
+++ b/registration/tests/test_hmac_workflow.py
@@ -121,7 +121,7 @@ class HMACViewTests(ActivationTestCase):
         # a date (ACCOUNT_ACTIVATION_DAYS + 1) days in the past.
         user = self.user_model.objects.get(**self.user_lookup_kwargs)
         joined_timestamp = (
-            user.date_joined - datetime.datetime.fromtimestamp(0)
+            user.date_joined - datetime.datetime.fromtimestamp(86400)
         ).total_seconds()
         expired_timestamp = (
             joined_timestamp - (settings.ACCOUNT_ACTIVATION_DAYS + 1) * 86400

--- a/registration/tests/test_sending_email.py
+++ b/registration/tests/test_sending_email.py
@@ -1,9 +1,9 @@
+from django.contrib.auth import get_user_model
 from django.core import mail
 from django.test import TestCase, RequestFactory
 from django.test.utils import override_settings
+
 from ..backends.hmac.views import RegistrationView, ActivationView
-from django.contrib.auth import get_user_model
-from django.core.mail.backends.smtp import EmailBackend
 
 User = get_user_model()
 
@@ -90,7 +90,8 @@ class SendActivationEmailTestCase(TestCase):
             'from_email': 'test@o2.pl',
         }
         # send email to user
-        RegistrationView(request=self.request).send_activation_email(self.user, **kwargs)
+        RegistrationView(request=self.request)\
+            .send_activation_email(self.user, **kwargs)
         # grab email from outbox
         email = mail.outbox[0]
         # verify from_email

--- a/registration/tests/test_sending_email.py
+++ b/registration/tests/test_sending_email.py
@@ -1,0 +1,97 @@
+from django.core import mail
+from django.test import TestCase, RequestFactory
+from django.test.utils import override_settings
+from ..backends.hmac.views import RegistrationView, ActivationView
+from django.contrib.auth import get_user_model
+from django.core.mail.backends.smtp import EmailBackend
+
+User = get_user_model()
+
+
+@override_settings(
+    ACCOUNT_ACTIVATION_DAYS=7,
+    REGISTRATION_OPEN=True
+)
+class SendActivationEmailTestCase(TestCase):
+    """
+    Check if we send correct context in activation email.
+    Check if activation_key passed to email template can be
+    actually verified.
+    Subject template should contain only {{activation key}}.
+    Body template should contain {{scheme}}, {{expiration_days}}, {{site}}.
+    """
+    user_model = User
+
+    valid_data = {
+        User.USERNAME_FIELD: 'alice',
+        'email': 'alice@example.com',
+        'password': 'swordfish',
+    }
+
+    def setUp(self):
+        # clear the outbox
+        mail.outbox = []
+        # create inactive user
+        self.user = self.user_model.objects.create_user(**self.valid_data)
+        self.user.is_active = False
+        self.user.save()
+        # create sample request
+        self.request = RequestFactory()
+        self.request.is_secure = False
+
+    def test_send_activation_email(self):
+        """
+        Make sure that e-mail body and subject contains our context.
+        Verify user based on activation_key sent in email subject.
+        """
+        # send activation email to user
+        RegistrationView(request=self.request).send_activation_email(self.user)
+        # grab that email and verify that it contains desired data
+        email = mail.outbox[0]
+        # BODY
+        # scheme
+        self.assertIn('http', email.body)
+        # site
+        self.assertIn('example.com', email.body)
+        # expiration days
+        self.assertIn('7', email.body)
+        # user
+        self.assertIn(self.valid_data[User.USERNAME_FIELD], email.body)
+        # check if user is inactive
+        self.user.refresh_from_db()
+        self.assertIs(False, self.user.is_active)
+        # grab activation key from email subject and activate user
+        activation_key = email.subject
+        user = ActivationView().activate(activation_key=activation_key)
+        # make sure that's correct user
+        self.user.refresh_from_db()
+        self.assertEqual(self.user, user)
+        # make sure hes active
+        self.assertIs(True, self.user.is_active)
+
+    @override_settings(DEFAULT_FROM_EMAIL='from@example.com')
+    def test_send_activation_email_from_settings(self):
+        """
+        Check if function is picking up settings.
+        """
+        # send email to user
+        RegistrationView(request=self.request).send_activation_email(self.user)
+        # grab email from outbox
+        email = mail.outbox[0]
+        # verify from_email
+        self.assertEqual(email.from_email, 'from@example.com')
+
+    def test_send_activation_email_kwargs(self):
+        """
+        Test if additional kwargs are passed to function
+        and settings are overwritten.
+        """
+        kwargs = {
+            'from_email': 'test@o2.pl',
+        }
+        # send email to user
+        RegistrationView(request=self.request).send_activation_email(self.user, **kwargs)
+        # grab email from outbox
+        email = mail.outbox[0]
+        # verify from_email
+        self.assertEqual(email.from_email, kwargs['from_email'])

--- a/registration/tests/test_sending_email.py
+++ b/registration/tests/test_sending_email.py
@@ -81,6 +81,7 @@ class SendActivationEmailTestCase(TestCase):
         # verify from_email
         self.assertEqual(email.from_email, 'from@example.com')
 
+    @override_settings(DEFAULT_FROM_EMAIL='from@example.com')
     def test_send_activation_email_kwargs(self):
         """
         Test if additional kwargs are passed to function


### PR DESCRIPTION
This allows to pass custom kwargs to the send_activation_email function.
https://github.com/ubernostrum/django-registration/issues/144
For example:
````
from django.core.mail.backends.smtp import EmailBackend
from registration.backends.hmac.views import RegistrationView

class CustomReg(RegistrationView):
    def send_activation_email(self, user, **kwargs):
        kwargs['connection'] = EmailBackend(host='custom_host')
        super(CustomReg, self).send_activation_email(user, **kwargs)
````