### PR TITLE
Use user model from settings.AUTH_USER_MODEL

### DIFF
--- a/registration/forms.py
+++ b/registration/forms.py
@@ -55,6 +55,7 @@ class RegistrationForm(UserCreationForm):
             'password1',
             'password2'
         ]
+        model = User
         required_css_class = 'required'
 
     def clean(self):


### PR DESCRIPTION
If we don't set User, RegistrationForm will create user using auth.User model instead of the model defined by the user