### PR TITLE
Fixed scheme in activation_email.txt context always being https

### DIFF
--- a/registration/backends/hmac/views.py
+++ b/registration/backends/hmac/views.py
@@ -71,7 +71,7 @@ class RegistrationView(BaseRegistrationView):
         Build the template context used for the activation email.
 
         """
-        scheme = 'https' if self.request.is_secure else 'http'
+        scheme = 'https' if self.request.is_secure() else 'http'
         return {
             'scheme': scheme,
             'activation_key': activation_key,


### PR DESCRIPTION
Hello!
I've found a little bug in `activation_email.txt` template context: `is_secure` on Django request is method, not an attribute, so the condition is always True and the `scheme` in context is always "https", even when it's really not.

I realize noone uses HTTP these days, but still, that's a bug :smiley: 