### PR TITLE
Update default attribute in documentation

### DIFF
--- a/docs/activation-workflow.rst
+++ b/docs/activation-workflow.rst
@@ -134,7 +134,7 @@ start guide <default-templates>`.
 
       A string specifying the template to use for the body of the
       activation email. Default is
-      `"django_registration/activation_email.txt"`.
+      `"django_registration/activation_email_body.txt"`.
 
    .. attribute:: email_subject_template
 


### PR DESCRIPTION
Correct document the RegistrationView's `email_body_template` attribute default as `django_registration/activation_email_body.txt` as defined [here](https://github.com/ubernostrum/django-registration/blob/6617463731aa15a941bde9cef9fc235563c5c3d1/src/django_registration/backends/activation/views.py#L35).