### PR TITLE
Fix to issue #175 where multiple @ signs are not accounted for in val…

### DIFF
--- a/src/django_registration/validators.py
+++ b/src/django_registration/validators.py
@@ -263,7 +263,10 @@ def validate_confusables_email(value):
     """
     if '@' not in value:
         return
-    local_part, domain = value.split('@')
+
+    email_pieces = value.split('@')
+    local_part = email_pieces[0]
+    domain = email_pieces[1]
     if confusables.is_dangerous(local_part) or \
        confusables.is_dangerous(domain):
         raise ValidationError(CONFUSABLE_EMAIL, code='invalid')


### PR DESCRIPTION
This PR is to address this issue related to an error being raised when an email address contains more than one '@' sign: https://github.com/ubernostrum/django-registration/issues/175