### PR TITLE
Fix to issue #175 where multiple @ signs are not accounted for in validation

### DIFF
--- a/src/django_registration/validators.py
+++ b/src/django_registration/validators.py
@@ -263,7 +263,10 @@ def validate_confusables_email(value):
     """
     if '@' not in value:
         return
-    local_part, domain = value.split('@')
+
+    email_pieces = value.split('@')
+    local_part = email_pieces[0]
+    domain = email_pieces[1]
     if confusables.is_dangerous(local_part) or \
        confusables.is_dangerous(domain):
         raise ValidationError(CONFUSABLE_EMAIL, code='invalid')

--- a/src/django_registration/validators.py
+++ b/src/django_registration/validators.py
@@ -265,6 +265,9 @@ def validate_confusables_email(value):
         return
 
     email_pieces = value.split('@')
+    if len(email_pieces) != 2:
+        raise ValidationError(CONFUSABLE_EMAIL, code='invalid')
+
     local_part = email_pieces[0]
     domain = email_pieces[1]
     if confusables.is_dangerous(local_part) or \


### PR DESCRIPTION
This PR is to address this issue related to an error being raised when an email address contains more than one '@' sign: #175

This PR includes a recommendation by @mrts to raise a validation error if more than one '@' sign is in the email address.

It also fixes the underlying issue where splitting an email address with more or less than one '@' sign into a length two tuple will raise a 'ValueError: too many values to unpack'
