### PR TITLE
Set `model` meta attribute to current user model

### DIFF
--- a/src/django_registration/forms.py
+++ b/src/django_registration/forms.py
@@ -34,6 +34,7 @@ class RegistrationForm(UserCreationForm):
 
     """
     class Meta(UserCreationForm.Meta):
+        model = User
         fields = [
             User.USERNAME_FIELD,
             User.get_email_field_name(),


### PR DESCRIPTION
This prevents the error `Manager isn't available; User has been swapped for 'app_name.CustomUserModel'` from being thrown.