### PR TITLE
Fix some deprecation warnings.

### DIFF
--- a/src/django_registration/backends/activation/views.py
+++ b/src/django_registration/backends/activation/views.py
@@ -11,7 +11,7 @@ from django.contrib.sites.shortcuts import get_current_site
 from django.core import signing
 from django.template.loader import render_to_string
 from django.urls import reverse_lazy
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from django_registration import signals
 from django_registration.exceptions import ActivationError

--- a/src/django_registration/forms.py
+++ b/src/django_registration/forms.py
@@ -12,7 +12,7 @@ django-registration.
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.forms import UserCreationForm
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from . import validators
 

--- a/src/django_registration/validators.py
+++ b/src/django_registration/validators.py
@@ -10,7 +10,7 @@ from confusable_homoglyphs import confusables
 from django.core.exceptions import ValidationError
 from django.core.validators import EmailValidator, RegexValidator
 from django.utils.deconstruct import deconstructible
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 CONFUSABLE = _("This name cannot be registered. " "Please choose a different name.")

--- a/src/django_registration/views.py
+++ b/src/django_registration/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.http import HttpResponseRedirect
 from django.urls import reverse_lazy
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.views.generic.base import TemplateView
 from django.views.generic.edit import FormView
 
@@ -48,7 +48,7 @@ class RegistrationView(FormView):
 
         """
         if not self.registration_allowed():
-            return HttpResponseRedirect(force_text(self.disallowed_url))
+            return HttpResponseRedirect(force_str(self.disallowed_url))
         return super().dispatch(*args, **kwargs)
 
     def get_form(self, form_class=None):
@@ -126,7 +126,7 @@ class ActivationView(TemplateView):
         Return the URL to redirect to after successful redirection.
 
         """
-        return force_text(self.success_url)
+        return force_str(self.success_url)
 
     def get(self, *args, **kwargs):
         """
@@ -148,9 +148,7 @@ class ActivationView(TemplateView):
             signals.user_activated.send(
                 sender=self.__class__, user=activated_user, request=self.request
             )
-            return HttpResponseRedirect(
-                force_text(self.get_success_url(activated_user))
-            )
+            return HttpResponseRedirect(force_str(self.get_success_url(activated_user)))
         context_data = self.get_context_data()
         context_data.update(extra_context)
         return self.render_to_response(context_data)


### PR DESCRIPTION
I tried to upgrade one of my Django apps to Django 3.0 yester and when I ran my tests with python -Wa I got some deprecation warnings from this package. 

In The functions ugettext_lazy and force_text where deprecated in Django 3.0, see https://docs.djangoproject.com/en/3.0/releases/3.0/#deprecated-features-3-0

Both have very obvious trivial replacements for projects that only need to support Python 3 though, so I made two tiny commits replacing them with the new functions.