### PR TITLE
Correct template names.

### DIFF
--- a/docs/one-step-workflow.rst
+++ b/docs/one-step-workflow.rst
@@ -82,7 +82,7 @@ Templates
 The one-step workflow uses two templates:
 
 * `django_registration/registration_form.html`.
-* `django_registration/registration_disallowed.html`
+* `django_registration/registration_closed.html`
 
 See :ref:`the quick start guide <default-form-template>` for details
 of these templates.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -161,7 +161,7 @@ user that an email containing account-activation information has been
 sent.
 
 
-`django_registration/registration_disallowed.html`
+`django_registration/registration_closed.html`
 ``````````````````````````````````````````````````
 
 Used when registration of new user accounts is disabled. This template
@@ -311,7 +311,7 @@ reset, etc.).
 Finally, you will need to create following templates:
 
 * `django_registration/registration_form.html`
-* `django_registration/registration_disallowed.html`
+* `django_registration/registration_closed.html`
 
 See :ref:`the documentation above <default-form-template>` for details
 of these templates.


### PR DESCRIPTION
Replacing `_disallowed` with `_closed` in the documentation to reflect the actual behavior of this module. Will open an issue regarding duplicated text that I'm not in a position rewrite.