### PR TITLE
Grammatical Updates to quickstart.rst

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -8,7 +8,7 @@ installed; for details on that, see :ref:`the installation guide
 <install>`.
 
 The next steps will depend on which registration workflow you'd like
-to use. There two workflows built in to django-registration:
+to use. There are two workflows built into django-registration:
 
 * :ref:`The two-step activation workflow <activation-workflow>`, which
   implements a two-step process: a user signs up, then is emailed an


### PR DESCRIPTION
1) Was missing a word in the second paragraph.

2) As a 'phrasal verb', 'in to' should be a single word: 'into'.

>  8. build in or into, to build or incorporate as part of something else: *an allowance for travel built into the budget.*

Random House Kernerman Webster’s College Dictionary. S.v. "built into." Retrieved March 15 2020 from https://www.thefreedictionary.com/built+into