### PR TITLE
Fix RemovedInDjango40Warning from Signal arguments

### DIFF
--- a/src/django_registration/signals.py
+++ b/src/django_registration/signals.py
@@ -7,7 +7,9 @@ from django.dispatch import Signal
 
 
 # A new user has registered.
-user_registered = Signal(providing_args=["user", "request"])
+# Provided args: user, request
+user_registered = Signal()
 
 # A user has activated his or her account.
-user_activated = Signal(providing_args=["user", "request"])
+# Provided args: user, request
+user_activated = Signal()


### PR DESCRIPTION
Fix to removove the following warning I've started to see when running unittest in my django project.

```
/<path to venv/lib/python3.7/site-packages/django_registration/signals.py:13: RemovedInDjango40Warning:
The providing_args argument is deprecated. As it is purely documentational, it has no replacement.
If you rely on this argument as documentation, you can move the text to a code comment or docstring.

user_activated = Signal(providing_args=["user", "request"])
```

