### PR TITLE
Make registration_complete.html template required in one-step workflow

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -321,6 +321,7 @@ reset, etc.).
 Finally, you will need to create following templates:
 
 * `django_registration/registration_form.html`
+* `django_registration/registration_complete.html`
 * `django_registration/registration_closed.html`
 
 See :ref:`the documentation above <default-form-template>` for details


### PR DESCRIPTION
The `registration_complete.html` should be required in one-step workflow, otherwise upon successful user registration Django throws an exception `TemplateDoesNotExist at /accounts/register/complete/` (`django.template.loaders.filesystem.Loader: /home/jd/myproj/templates/django_registration/registration_complete.html (Source does not exist)`)