### PR TITLE
Fix warning from tox about external tools

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -75,6 +75,9 @@ commands_post =
 commands =
   coverage run --source django_registration runtests.py
   coverage report -m
+whitelist_externals =
+  find
+  rm
 deps =
   coverage
   django22: Django>=2.2,<3.0


### PR DESCRIPTION
When running tests with tox 3.13.2 the following errors are repeated for each test permutation

  WARNING: test command found but not installed in testenv
    cmd: /usr/bin/find
    env: /home/tomas/src/django-registration/.tox/py39-django32
  Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

  DEPRECATION WARNING: this will be an error in tox 4 and above!

  WARNING: test command found but not installed in testenv
    cmd: /usr/bin/rm
    env: /home/tomas/src/django-registration/.tox/py39-django32
  Maybe you forgot to specify a dependency? See also the whitelist_externals envconfig setting.

  DEPRECATION WARNING: this will be an error in tox 4 and above!

This commit adds rm and find to the `whitelist_external` setting in tox.ini and fixes these warnings.