### PR TITLE
Use custom user model in RegistrationForm

### DIFF
--- a/docs/custom-user.rst
+++ b/docs/custom-user.rst
@@ -18,6 +18,14 @@ order to do so. If you are using a custom user model, please read this
 document thoroughly *before* using django-registration, in order to
 ensure you've taken all the necessary steps to ensure support.
 
+Your customer user model **needs** to define two properties:
+
+1. USERNAME_FIELD
+2. EMAIL_FIELD
+
+These fields can be the same value. See `Django's AbstractUser <https://github.com/django/django/blob/main/django/contrib/auth/models.py#L334>`_
+for an example implementation.
+
 The process for using a custom user model with django-registration can
 be summarized as follows:
 
@@ -166,7 +174,7 @@ do **not** directly edit django-registration's code):
 
     from mycustomuserapp.models import MyCustomUser
 
-    
+
     class MyCustomUserForm(RegistrationForm):
         class Meta(RegistrationForm.Meta):
             model = MyCustomUser
@@ -184,7 +192,7 @@ class you wrote:
     from django.urls import include, path
 
     from django_registration.backends.activation.views import RegistrationView
-    
+
     from mycustomuserapp.forms import MyCustomUserForm
 
 

--- a/src/django_registration/forms.py
+++ b/src/django_registration/forms.py
@@ -34,9 +34,12 @@ class RegistrationForm(UserCreationForm):
     """
 
     class Meta(UserCreationForm.Meta):
-        fields = [
-            User.USERNAME_FIELD,
-            User.get_email_field_name(),
+        model = User
+        fields = [User.USERNAME_FIELD]
+        email_field_name = User.get_email_field_name()
+        if User.USERNAME_FIELD != email_field_name:
+            fields.append(email_field_name)
+        fields += [
             "password1",
             "password2",
         ]


### PR DESCRIPTION
By default, Django will use its own default User model when initializing the CreationForm.

This will cause FieldErrors to be raised when a customer user model is provided but doesn't contain the same fields as in Django's default implementation.

That's why we use the custom user model to instantiate a CreationForm instead. The implementation can now have any fields it wants as long as it's compatible with Django's AbstractUser.

Fixes #234